### PR TITLE
Add a bunny to the demo so its more 3D

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -6,6 +6,7 @@ var camera = require("game-shell-orbit-camera")(shell)
 var mat4 = require("gl-mat4")
 var bunny = require("bunny")
 var createMesh = require("gl-mesh")
+var createSimpleShader = require("simple-3d-shader")
 
 var iframe = document.createElement('iframe');
 iframe.src = 'http://browserify.org';
@@ -24,7 +25,7 @@ camera.lookAt([0,0,-3], [0,0,0], [0,1,0])
 // a slight rotation for effect
 camera.rotate([1/4,-1/4,0], [0,0,0])
 
-var bunnyMesh
+var bunnyMesh, bunnyShader
 
 shell.on('gl-init', function() {
   // allow pointer events to pass through canvas to CSS world behind
@@ -34,6 +35,7 @@ shell.on('gl-init', function() {
   css3d.ginit(shell.gl);
 
   bunnyMesh = createMesh(shell.gl, bunny);
+  bunnyShader = createSimpleShader(shell.gl)
 });
 
 var button = document.createElement('button');
@@ -52,13 +54,26 @@ shell.on('gl-resize', function(width, height) {
   css3d.updatePerspective(cameraFOVradians, shell.width, shell.height);
 });
 
+var bunnyModelMatrix = mat4.create();
+mat4.scale(bunnyModelMatrix, bunnyModelMatrix, [1/10, 1/10, 1/10]);
+mat4.translate(bunnyModelMatrix, bunnyModelMatrix, [-15, 0, 0]); // slightly overlapping gl-css3d
+var bunnyColor = [1, 0, 0]; // solid red, no texture
+
 shell.on('gl-render', function() {
   var proj = mat4.perspective(mat4.create(), cameraFOVradians, shell.width/shell.height, 0.1, 1000.0)
   var view = camera.view()
 
   css3d.render(view, proj);
 
-  bunnyMesh.bind(css3d.cutoutShader); // TODO: better shader
+  // draw another 3D object so the demo is more convincing
+  bunnyShader.bind();
+  bunnyShader.uniforms.projection = proj;
+  bunnyShader.uniforms.view = view;
+  bunnyShader.uniforms.model = bunnyModelMatrix;
+  bunnyShader.attributes.position.location = 0
+  bunnyShader.attributes.color = bunnyColor;
+
+  bunnyMesh.bind(bunnyShader);
   bunnyMesh.draw();
   bunnyMesh.unbind();
 })

--- a/demo.js
+++ b/demo.js
@@ -4,6 +4,8 @@ var createCSS3D = require('./');
 var shell = require("gl-now")({clearColor: [0.2, 0.4, 0.8, 1.0]})
 var camera = require("game-shell-orbit-camera")(shell)
 var mat4 = require("gl-mat4")
+var bunny = require("bunny")
+var createMesh = require("gl-mesh")
 
 var iframe = document.createElement('iframe');
 iframe.src = 'http://browserify.org';
@@ -22,12 +24,16 @@ camera.lookAt([0,0,-3], [0,0,0], [0,1,0])
 // a slight rotation for effect
 camera.rotate([1/4,-1/4,0], [0,0,0])
 
+var bunnyMesh
+
 shell.on('gl-init', function() {
   // allow pointer events to pass through canvas to CSS world behind
   shell.canvas.style.pointerEvents = 'none';
   shell.canvas.parentElement.style.pointerEvents = 'none';
 
   css3d.ginit(shell.gl);
+
+  bunnyMesh = createMesh(shell.gl, bunny);
 });
 
 var button = document.createElement('button');
@@ -51,4 +57,8 @@ shell.on('gl-render', function() {
   var view = camera.view()
 
   css3d.render(view, proj);
+
+  bunnyMesh.bind(css3d.cutoutShader); // TODO: better shader
+  bunnyMesh.draw();
+  bunnyMesh.unbind();
 })

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "gl-now": "^1.4.0",
-    "game-shell-orbit-camera": "^1.0.0",
-    "wzrd": "^1.2.1",
     "bunny": "^1.0.1",
-    "gl-mesh": "^0.1.0"
+    "game-shell-orbit-camera": "^1.0.0",
+    "gl-now": "^1.4.0",
+    "simple-3d-shader": "0.0.0",
+    "wzrd": "^1.2.1"
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   "devDependencies": {
     "gl-now": "^1.4.0",
     "game-shell-orbit-camera": "^1.0.0",
-    "wzrd": "^1.2.1"
+    "wzrd": "^1.2.1",
+    "bunny": "^1.0.1",
+    "gl-mesh": "^0.1.0"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
To make the demo more interesting (instead of merely a flat movable plane, which doesn't show it is part of WebGL), demonstrating overlapping 3D, as in this screenshot from [voxel-webview](https://github.com/deathcap/voxel-webview) for three.js:

![687474703a2f2f692e696d6775722e636f6d2f546c555a5847592e706e67-1](https://cloud.githubusercontent.com/assets/5897956/6207595/e852c22a-b55a-11e4-9df0-70070033bc4b.png)

initial commit reusing the same shader as for the cutout, so the [bunny](https://github.com/mikolalysenko/bunny) doesn't yet look like this:

![68747470733a2f2f7261772e6769746875622e636f6d2f6d696b6f6c616c7973656e6b6f2f62756e6e792f6d61737465722f696d616765732f62756e6e792e706e67](https://cloud.githubusercontent.com/assets/5897956/6207593/dca35fc0-b55a-11e4-81db-fb5c150549b6.png)
